### PR TITLE
Resolve explicit extensions as well as implicit

### DIFF
--- a/lib/sassc/rails/importer.rb
+++ b/lib/sassc/rails/importer.rb
@@ -116,8 +116,7 @@ module SassC
           end
         end
 
-        # TODO: Raise an error from SassC here
-        raise ArgumentError.new("file not found: #{path}")
+        SassC::Importer::Import.new(path)
       end
 
       private

--- a/test/dummy/app/assets/stylesheets/imports_test.scss
+++ b/test/dummy/app/assets/stylesheets/imports_test.scss
@@ -1,6 +1,7 @@
 @import "partials/css_sass_import";
 @import "partials/sass_import";
 @import "partials/scss_import";
+@import "partials/explicit_extension_import.foo";
 @import "globbed/**/*";
 @import "subfolder/plain";
 @import "subfolder/second_level";

--- a/test/dummy/app/assets/stylesheets/partials/_explicit_extension_import.foo
+++ b/test/dummy/app/assets/stylesheets/partials/_explicit_extension_import.foo
@@ -1,0 +1,3 @@
+.partial-foo {
+  color: green
+}

--- a/test/sassc_rails_test.rb
+++ b/test/sassc_rails_test.rb
@@ -126,6 +126,7 @@ class SassRailsTest < MiniTest::Unit::TestCase
     assert_match /top-level/,                css_output
     assert_match /partial-sass/,             css_output
     assert_match /partial-scss/,             css_output
+    assert_match /partial-foo/,              css_output
     assert_match /sub-folder-relative-sass/, css_output
     assert_match /sub-folder-relative-scss/, css_output
     assert_match /not-a-partial/,            css_output


### PR DESCRIPTION
We have imports in our codebase (https://github.com/alphagov/whitehall/blob/a141931d01022a59b6ea7898f523c68d09c3433f/app/assets/stylesheets/frontend/base.scss#L10) that explicitly specify ".scss". These imports worked under Ruby Sass, but not libsass.