### PR TITLE
Set line-comments by default like sass-rails

### DIFF
--- a/lib/sassc/rails/railtie.rb
+++ b/lib/sassc/rails/railtie.rb
@@ -11,6 +11,9 @@ module SassC::Rails
     # Initialize the load paths to an empty array
     config.sass.load_paths       = []
 
+    # Display line comments above each selector as a debugging aid
+    config.sass.line_comments    = true
+
     # Set the default stylesheet engine
     # It can be overridden by passing:
     #     --stylesheet_engine=sass
@@ -35,7 +38,7 @@ module SassC::Rails
       # Override stylesheet engine to the preferred syntax
       config.app_generators.stylesheet_engine syntax
 
-      # Establish configuration defaults that are evironmental in nature
+      # Establish configuration defaults that are environmental in nature
       # if config.sass.full_exception.nil?
       #   # Display a stack trace in the css output when in development-like environments.
       #   config.sass.full_exception = app.config.consider_all_requests_local

--- a/lib/sassc/rails/template.rb
+++ b/lib/sassc/rails/template.rb
@@ -10,6 +10,7 @@ module SassC::Rails
 
         options = {
           filename: input[:filename],
+          line_comments: line_comments?,
           syntax: self.class.syntax,
           load_paths: input[:environment].paths,
           importer: SassC::Rails::Importer,
@@ -40,6 +41,7 @@ module SassC::Rails
       def evaluate(context, locals, &block)
         options = {
           filename: eval_file,
+          line_comments: line_comments?,
           syntax: syntax,
           load_paths: context.environment.paths,
           importer: SassC::Rails::Importer,
@@ -76,6 +78,10 @@ module SassC::Rails
 
     def sass_style
       (Rails.application.config.sass.style || :expanded).to_sym
+    end
+
+    def line_comments?
+      Rails.application.config.sass.line_comments
     end
   end
 

--- a/sassc-rails.gemspec
+++ b/sassc-rails.gemspec
@@ -23,8 +23,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency 'mocha'
 
-  # unfortunately we require sass for now, so that we can
-  # reuse portions of the sprockets template
+  # Unfortunately we require sass for now, so that we can
+  # reuse portions of the Sprockets template
   spec.add_dependency 'sass'
   spec.add_dependency "sassc", "~> 1.5"
 

--- a/test/sassc_rails_test.rb
+++ b/test/sassc_rails_test.rb
@@ -17,6 +17,9 @@ class SassRailsTest < MiniTest::Unit::TestCase
     @app.config.sass.preferred_syntax = :scss
     @app.config.sass.load_paths       = []
 
+    # Not actually a default, but it makes assertions more complicated
+    @app.config.sass.line_comments    = false
+
     Rails.backtrace_cleaner.remove_silencers!
   end
 
@@ -159,6 +162,15 @@ class SassRailsTest < MiniTest::Unit::TestCase
     @app.config.sass.style = :nested
     initialize!
     assert_equal :nested, Rails.application.config.sass.style
+  end
+
+  def test_line_comments_active_in_dev
+    @app.config.sass.line_comments = true
+    initialize_dev!
+
+    css_output = render_asset("css_scss_handler.css.scss")
+    assert_match %r{/* line 1}, css_output
+    assert_match %r{.+/sassc-rails/test/dummy/app/assets/stylesheets/css_scss_handler.css.scss}, css_output
   end
 
   def test_context_is_being_passed_to_erb_render


### PR DESCRIPTION
Sets `line_comments` by default like `sass-rails`

Note that this depends on a patch version bump in `sassc-ruby`