### PR TITLE
Includes #to_native into Sass::Script::Value types

### DIFF
--- a/lib/sassc/rails/functions.rb
+++ b/lib/sassc/rails/functions.rb
@@ -9,3 +9,6 @@ module Sprockets
 end
 
 ::SassC::Script::Functions.send :include, Sprockets::SassFunctions
+
+::Sass::Script::Value::String.send :include, SassC::Script::NativeString
+::Sass::Script::Value::Color.send :include, SassC::Script::NativeColor


### PR DESCRIPTION
Mixes our `#to_native` functionality into Sass types, which we need for reasons described in https://github.com/bolandrm/sassc-ruby/pull/16