### PR TITLE
Stop overriding the app css_compressor setting

### DIFF
--- a/lib/sassc/rails/railtie.rb
+++ b/lib/sassc/rails/railtie.rb
@@ -53,9 +53,7 @@ module SassC::Rails
     end
 
     initializer :setup_compression, group: :all do |app|
-      app.config.assets.css_compressor = nil
-
-      if !Rails.env.development?
+      unless Rails.env.development?
         app.config.assets.css_compressor ||= :sass
       else
         # Use expanded output instead of the sass default of :nested unless specified

--- a/test/sassc_rails_test.rb
+++ b/test/sassc_rails_test.rb
@@ -13,6 +13,7 @@ class SassRailsTest < MiniTest::Unit::TestCase
     @app.config.log_level = :debug
 
     # reset config back to default
+    @app.config.assets.css_compressor = nil
     @app.config.sass = ActiveSupport::OrderedOptions.new
     @app.config.sass.preferred_syntax = :scss
     @app.config.sass.load_paths       = []


### PR DESCRIPTION
I fail to understand why this gem is doing so, but it's preventing users to configure the CSS compressing as they will.

@bolandrm could we remove it, or am I missing something?

cc @edward 